### PR TITLE
Fix: remove chan during rule group evaluation

### DIFF
--- a/querybuilder/evaluator_test.go
+++ b/querybuilder/evaluator_test.go
@@ -35,3 +35,14 @@ func TestMatch(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkMatch(b *testing.B) {
+	qb := New(parseJson(rulesetStr))
+	for i := 0; i < b.N; i++ {
+		qb.Match(map[string]interface{}{
+			"float_equal": 1.3,
+			"foo":         "bar",
+			"baz":         123,
+		})
+	}
+}


### PR DESCRIPTION
# Bug
In production, we observed that the application using this library kept increasing in RAM and didn't recover. The `Match()` method is invoked at most 1000 times per hour during peak load.

# RCA
Using [pprof](https://golang.org/pkg/net/http/pprof/) we identified `inuse_objects` and `inuse_space` kept increasing. With this we were able to identify the root cause.

During the lazy evaluation, the `Evaluate` method exited without closing the result channel. This caused the channel to remain open because the sender continues to run in a goroutine.

# Fix
Our use-case would have at most 50 rules and therefore we traded off the optimisation to evaluate the rules sequentially. We needed a quick fix and preferred the simplicity of this solution. Usually, our production rulesets have 5 rules.

The newly added benchmark was tested before and after the changes in business logic. For a small number of rules, the ns/op metric is better after code changes. PFA the cpu, memory and block profile before and after the changes.

[Archive.zip](https://github.com/enjoei/pkg/files/6269822/Archive.zip)

